### PR TITLE
Bug report/issue#110 webhooks

### DIFF
--- a/checkout/templates/checkout/confirmation_emails/confirmation_email_body.html
+++ b/checkout/templates/checkout/confirmation_emails/confirmation_email_body.html
@@ -1,4 +1,4 @@
-Hello {{ order.full_name }}!
+<h1 class="text-sm text-purple">Hi {{ order.full_name }}!</h1>
 
 This is a confirmation of your order at Swanbourne Village Stores. Your order information is below:
 
@@ -9,7 +9,7 @@ Total: {{ currency }}{{ order.grand_total }}
 
 We've got your phone number on file as {{ order.phone_number }}.
 
-If you have any questions, feel free to contact us at {{ contact_email }}.
+If you have any questions, feel free to contact us at {{ store_email }}.
 
 Thank you for your order!
 

--- a/checkout/templates/checkout/confirmation_emails/confirmation_email_subject.txt
+++ b/checkout/templates/checkout/confirmation_emails/confirmation_email_subject.txt
@@ -1,2 +1,1 @@
-
 Swanbourne Village Stores Confirmation for Order Number {{ order.order_number }}

--- a/checkout/webhook_handler.py
+++ b/checkout/webhook_handler.py
@@ -22,10 +22,10 @@ class StripeWebhookHandler:
         """Send the user a confirmation email"""
         cust_email = order.email
         subject = render_to_string(
-            'checkout/confirmation-emails/confirmation-email-subject.txt',
+            'checkout/confirmation_emails/confirmation_email_subject.txt',
             {'order': order})
         body = render_to_string(
-            'checkout/confirmation-emails/confirmation-email-body.txt',
+            'checkout/confirmation_emails/confirmation_email_body.html',
             {'order': order, 'contact_email': settings.DEFAULT_FROM_EMAIL})
 
         send_mail(

--- a/swanbourne_stores/settings.py
+++ b/swanbourne_stores/settings.py
@@ -206,4 +206,8 @@ else:
 STRIPE_CURRENCY = 'GBP'
 STRIPE_PUBLIC_KEY = os.environ.get('STRIPE_PUBLIC_KEY')
 STRIPE_SECRET_KEY = os.environ.get('STRIPE_SECRET_KEY')
-STRIPE_WH_SECRET = os.environ.get('STRIPE_WH_SECRET')
+
+if DEBUG:
+    STRIPE_WH_SECRET = os.environ.get('STRIPE_WH_SECRET_DEVELOP')
+else:
+    STRIPE_WH_SECRET = os.environ.get('STRIPE_WH_SECRET_LIVE')


### PR DESCRIPTION
Changed the port to public in development which gave the 500 error of no template existing in the file path specified in the _send_confirmation_email method in  checkout/webhook_handler.py. The file location changed and the webhook is working properly.

Also added a DEBUG check to select the endpoint depending on its status.
